### PR TITLE
fix(members): avoid avatar exceptions on login and orphan references

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -401,6 +401,9 @@ def create_thumbnail(image: models.FileField, size: int) -> InMemoryUploadedFile
       than this, it is resized.
   :return: An InMemoryUploadedFile representing the thumbnail.
   """
+  if not image.storage.exists(image.name):
+    logger.warning(f"create_thumbnail: file '{image.name}' not found in storage, skipping thumbnail generation")
+    return image
   if image.file.closed:
     image.file = default_storage.open(image.name, "rb")
   with Image.open(image.file) as imgf:

--- a/members/models.py
+++ b/members/models.py
@@ -253,6 +253,12 @@ class Member(AbstractUser):
   def get_manager(self):
     return self.member_manager if self.member_manager else self
 
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    # Track avatar name so save() regenerates thumbnails only when the avatar actually
+    # changes, not on every save (e.g. allauth updating last_login on login triggers save()).
+    self._original_avatar_name = self.avatar.name if self.avatar else None
+
   def clean(self):
     if self.deathdate:
       if self.deathdate < self.birthdate:
@@ -278,12 +284,18 @@ class Member(AbstractUser):
 
   def save(self, *args, **kwargs):
     self.clean()  # clean before save
-    if self.avatar:
+    # Only regenerate thumbnails when the avatar actually changed, so a plain save
+    # (e.g. login updating last_login) doesn't read/rewrite the avatar file.
+    original_avatar_name = getattr(self, "_original_avatar_name", None)
+    current_avatar_name = self.avatar.name if self.avatar else None
+    avatar_changed = current_avatar_name != original_avatar_name
+
+    if avatar_changed and self.avatar:
       # resize avatar itself
       self.avatar = create_thumbnail(self.avatar, settings.AVATARS_SIZE)
     super().save(*args, **kwargs)
 
-    if self.avatar:
+    if avatar_changed and self.avatar:
       # generate minified for post/ads/chat
       mini = create_thumbnail(self.avatar, settings.AVATARS_MINI_SIZE)
       mini.seek(0)
@@ -295,14 +307,19 @@ class Member(AbstractUser):
         logger.error(f"ERROR: saved_path != self.avatar_mini_name: {saved_path} != {self.avatar_mini_name}")
       logger.debug(f"Resized and saved avatar for {self.full_name} in {saved_path}, size: {settings.AVATARS_MINI_SIZE}")
 
+    # Refresh tracking so a subsequent save without change skips thumbnail regeneration
+    self._original_avatar_name = self.avatar.name if self.avatar else None
+
   def delete(self, *args, **kwargs):
     self.delete_avatar()
     super().delete(*args, **kwargs)
 
   def delete_avatar(self):
     if self.avatar:
-      default_storage.delete(self.avatar.file.name)
-      default_storage.delete(self.avatar_mini_name)
+      if self.avatar.storage.exists(self.avatar.name):
+        default_storage.delete(self.avatar.name)
+      if self.avatar.storage.exists(self.avatar_mini_name):
+        default_storage.delete(self.avatar_mini_name)
       self.avatar = None
 
 

--- a/members/tests/tests_member.py
+++ b/members/tests/tests_member.py
@@ -211,6 +211,40 @@ class MemberAvatarTest(MemberTestCaseMixin, TestCase):
     self.assertEqual(test_ext, test_ext)
     self.assertTrue(avatar_prefix.startswith(testbn_prefix))
 
+  def test_avatar_not_regenerated_on_unchanged_save(self):
+    # A plain re-save (e.g. allauth updating last_login on login triggers save())
+    # must NOT regenerate thumbnails when the avatar hasn't changed.
+    from django.core.files.uploadedfile import InMemoryUploadedFile
+    from io import BytesIO
+    from PIL import Image
+    from unittest.mock import patch
+    import sys
+    from members.models import create_thumbnail as real_create_thumbnail
+
+    self.member = self.create_member()
+    avatar_file = os.path.join(os.path.dirname(__file__), "resources", self.base_avatar)
+    membuf = BytesIO()
+    with Image.open(avatar_file) as img:
+      img.save(membuf, format="JPEG", quality=90)
+    size = sys.getsizeof(membuf)
+    self.member.avatar = InMemoryUploadedFile(membuf, "ImageField", self.base_avatar, "image/jpeg", size, None)
+    self.member.save()
+    self.assertTrue(default_storage.exists(self.member.avatar.name))
+
+    with patch("members.models.create_thumbnail", side_effect=real_create_thumbnail) as mock_thumb:
+      self.member.save()
+      mock_thumb.assert_not_called()
+
+  def test_create_thumbnail_skips_missing_file(self):
+    # create_thumbnail must not raise when the referenced file is missing from storage
+    # (orphan avatar reference); it returns the image unchanged instead.
+    from core.utils import create_thumbnail
+
+    member = self.create_member()
+    member.avatar.name = "avatars/does_not_exist.webp"  # orphan reference, no physical file
+    result = create_thumbnail(member.avatar, settings.AVATARS_SIZE)
+    self.assertIs(result, member.avatar)
+
 
 class ManagedMemberChangeTests(MemberViewTestMixin, MemberTestCase):
   def setUp(self):


### PR DESCRIPTION
## Problem

`POST /members/login/` returned a **500** when a member's avatar referenced a file missing from storage:

```
FileNotFoundError: .../media/avatars/20140101_130051_Android.webp
File "core/utils.py", line 404, in create_thumbnail
    if image.file.closed:   # lazy-loads the file, raises if missing
```

Two root causes:
1. `Member.save()` regenerated the avatar thumbnails on **every** save — including allauth updating `last_login` on login — so it read the avatar file on each login.
2. Several call sites (`create_thumbnail`, `delete_avatar`) accessed the file without guarding for absence, raising on orphan references.

## Changes

- **`members/models.py`**
  - `__init__` tracks `_original_avatar_name`; `save()` regenerates avatar + mini thumbnails **only when the avatar actually changed**.
  - `delete_avatar()` checks `storage.exists()` before deleting (was raising on orphan references too).
- **`core/utils.py`**
  - `create_thumbnail()` returns the image unchanged with a warning when the file is missing, instead of raising.

## Tests

- `test_avatar_not_regenerated_on_unchanged_save` — a plain re-save (e.g. login) does not call `create_thumbnail`.
- `test_create_thumbnail_skips_missing_file` — `create_thumbnail` does not raise on a missing file.

`make check` (ruff/mypy/bandit/pip-audit) ✅ and `members.tests.tests_member` (22 tests) ✅ pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
